### PR TITLE
Require claims to be signed with subject address and claim type

### DIFF
--- a/contracts/ClaimHolder.sol
+++ b/contracts/ClaimHolder.sol
@@ -110,8 +110,12 @@ contract ClaimHolder is KeyHolder, ERC735 {
         bytes32 sa;
         uint8 va;
 
+        bytes memory prefix = "\x19Ethereum Signed Message:\n32"; // prefix used by web3
         bytes memory sig = claims[_claimId].signature;
+        uint256 claimType = claims[_claimId].claimType;
         bytes32 claimData = claims[_claimId].data;
+        bytes32 dataHash = keccak256(address(this), claimType, claimData);
+        bytes32 prefixedHash = keccak256(prefix, dataHash);
 
         // Check the signature length
         if (sig.length != 65) {
@@ -129,7 +133,7 @@ contract ClaimHolder is KeyHolder, ERC735 {
           va += 27;
         }
 
-        return (claimData, ra, sa, va);
+        return (prefixedHash, ra, sa, va);
     }
 
     function recoverIssuer(bytes32 _claimId)

--- a/test/ClaimVerifier.js
+++ b/test/ClaimVerifier.js
@@ -43,16 +43,18 @@ describe('ClaimVerifier.sol', async function() {
   })
 
   it('should allow Verifier to post a claim to User identity via execute', async function() {
-    var data = '{ "did": "did:facebook:12345" }'
-    var signed = await web3.eth.accounts.sign(data, prvSigner)
+    var data = web3.utils.sha3('{ "did": "did:facebook:12345" }')
+    var claimType = 3
+    var hashed = web3.utils.soliditySha3(UserIdentity._address, claimType, data)
+    var signed = await web3.eth.accounts.sign(hashed, prvSigner)
 
     var abi = await UserIdentity.methods
       .addClaim(
-        3,
+        claimType,
         2,
         IdentityVerifier._address,
         signed.signature,
-        signed.messageHash,
+        data,
         'abc.com'
       )
       .encodeABI()


### PR DESCRIPTION
This makes claims valid only for the intended recipient and claim type.

The prefix stuff here is being done to accomodate the prefixing done by
web3 when signing messages, as a security measure
(https://github.com/ethereum/go-ethereum/issues/3731). Because this
signing is most likely going to be done on servers of major claim
validators rather than from end-user clients, the web3 prefix could
probably be bypassed. But to keep things simple I just adjusted the
solidity code to use this prefix. I think it's adequate for now.