### PR TITLE
Key/name mismatch

### DIFF
--- a/contracts/ClaimHolder.sol
+++ b/contracts/ClaimHolder.sol
@@ -24,7 +24,7 @@ contract ClaimHolder is KeyHolder, ERC735 {
         KeyHolder issuer = KeyHolder(issuer);
 
         if (msg.sender != address(this)) {
-          require(keyHasPurpose(keccak256(msg.sender), 3), "Sender does not have management key");
+          require(keyHasPurpose(keccak256(msg.sender), 3), "Sender does not have Claim Signer key");
         }
 
         if (claims[claimId].issuer != _issuer) {

--- a/contracts/ClaimHolder.sol
+++ b/contracts/ClaimHolder.sol
@@ -24,7 +24,7 @@ contract ClaimHolder is KeyHolder, ERC735 {
         KeyHolder issuer = KeyHolder(issuer);
 
         if (msg.sender != address(this)) {
-          require(keyHasPurpose(keccak256(msg.sender), 3), "Sender does not have Claim Signer key");
+          require(keyHasPurpose(keccak256(msg.sender), 3), "Sender does not have claim signer key");
         }
 
         if (claims[claimId].issuer != _issuer) {


### PR DESCRIPTION
Key Purpose 3 is here required (Claim_Signer_Key) but 'management key' is specified in the error return. I've resolved the mismatch in favour of Claim_signer_key which I believe is appropriate for addClaim. 
