### PR TITLE
Relay execution value

### DIFF
--- a/contracts/KeyHolder.sol
+++ b/contracts/KeyHolder.sol
@@ -83,7 +83,7 @@ contract KeyHolder is ERC725 {
 
         if (_approve == true) {
             executions[_id].approved = true;
-            success = executions[_id].to.call(executions[_id].data, 0);
+            success = executions[_id].to.call.value(executions[_id].value)(executions[_id].data, 0);
             if (success) {
                 executions[_id].executed = true;
                 emit Executed(


### PR DESCRIPTION
This isn't tested yet — I'm not sure it's desired. The standard should likely be updated first, as per [this comment and the next](https://github.com/ethereum/EIPs/issues/725#issuecomment-398750048) (or the contract should include another `payable` function). Thoughts?